### PR TITLE
waffle.io Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Stories in Ready](https://badge.waffle.io/crohling/monitor.png?label=ready&title=Ready)](https://waffle.io/crohling/monitor)
 # Monitor [![Build Status](https://travis-ci.org/crohling/monitor.svg?branch=master)](https://travis-ci.org/crohling/monitor)
 A simple TCP service monitor
 


### PR DESCRIPTION
Merge this to receive a badge indicating the number of issues in the ready column on your waffle.io board at https://waffle.io/crohling/monitor

This was requested by a real person (user crohling) on waffle.io, we're not trying to spam you.
